### PR TITLE
Added more tests; updated broken tests

### DIFF
--- a/t/01_request.t
+++ b/t/01_request.t
@@ -3,9 +3,11 @@
 use HTTP::Server::Async;
 use Test;
 
-plan 3;
+plan 10;
 
 my $s = HTTP::Server::Async.new;
+isa_ok $s, HTTP::Server::Async;
+is $s.responsestack.elems, 0, 'Response stack contains no elements yet';
 
 $s.register(sub ($request, $response) {
   $response.headers<Content-Type> = 'text/plain';
@@ -14,6 +16,8 @@ $s.register(sub ($request, $response) {
   $response.close("Hello world!");
   return True;
 });
+ok $s.responsestack.elems, 'Response stack contains elements';
+isa_ok $s.responsestack[0], Sub;
 
 $s.listen;
 
@@ -21,6 +25,10 @@ my $host = '127.0.0.1';
 my $port = 8080;
  
 my $client = IO::Socket::INET.new(:$host, :$port);
+isa_ok $client, IO::Socket::INET;
+is $client.host, $host, 'IO::Socket::INET correct host';
+is $client.port, $port, 'IO::Socket::INET correct port';
+
 $client.send("GET / HTTP/1.0\r\n\r\n");
 my @data;
 while (my $str = $client.recv) {
@@ -28,7 +36,7 @@ while (my $str = $client.recv) {
 }
 $client.close;
 
-ok @data[0] = "200 OK\r\n";
-ok @data[1] = "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n";
-ok @data[2] = "Hello world!";
+is @data[0], "HTTP/1.1 200 OK\r\n", "Code: 200";
+is @data[1], "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n", "Content-type correct";
+is @data[2], "Hello world!", "Content: Hello World!";
 


### PR DESCRIPTION
More tests that should fail on earlier perl6 version that get stuck. Corrected the following tests which were just assignments (aka ok 1;)

-ok @data[0] = "200 OK\r\n";
-ok @data[1] = "Content-Type: text/plain\r\nContent-Length: 12\r\n\r\n";
-ok @data[2] = "Hello world!";

Tried to use regex for:
is @data[0], "HTTP/1.1 200 OK\r\n", "Code: 200";
but could not get it to work (ok @data[0] ~~ /200 OK/, "Code: 200";)
